### PR TITLE
Fix profile info new / confirm password field

### DIFF
--- a/app/src/main/java/com/example/caregiver/ProfileInfo.java
+++ b/app/src/main/java/com/example/caregiver/ProfileInfo.java
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment;
 import android.preference.PreferenceManager;
 import android.text.Html;
 import android.text.InputType;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/com/example/caregiver/ProfileInfo.java
+++ b/app/src/main/java/com/example/caregiver/ProfileInfo.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 import android.preference.PreferenceManager;
 import android.text.Html;
 import android.text.InputType;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -51,10 +52,6 @@ public class ProfileInfo extends Fragment {
     public String currentEmail;
     public String currentName;
     public String currentNotes;
-
-    // Color for error and success message
-    int red;
-    int green;
 
     public class ProfileUser {
         public String name;
@@ -118,11 +115,10 @@ public class ProfileInfo extends Fragment {
         emailField = (EditText) view.findViewById(R.id.profileEmail);
         notesField = (EditText) view.findViewById(R.id.profileNotes);
         newPasswordField = (EditText) view.findViewById(R.id.profileNewPassword);
-        confirmPasswordField = (EditText) view.findViewById(R.id.profileNewPassword2);
+        confirmPasswordField = (EditText) view.findViewById(R.id.profileConfirmPassword);
         caregiveeLabel = (TextView) view.findViewById(R.id.profileTextLabel);
         errorMessage = (TextView) view.findViewById(R.id.profileInfoMessage);
-        red = view.getResources().getColor(R.color.red);
-        green = view.getResources().getColor(R.color.green);
+
 
         // This page is opened when user clicked on "View Profile" from the homepage.
         Bundle args = this.getArguments();
@@ -164,13 +160,20 @@ public class ProfileInfo extends Fragment {
     /**
      * Render the error and success message field.
      * @param sourceString The text message to be displayed.
-     * @param color The color for the text message (red for error, green for success).
      */
-    public void displayMessage(String sourceString, int color) {
+    public void displayErrorMessage(String sourceString) {
         errorMessage.setText(Html.fromHtml(sourceString));
         errorMessage.setVisibility(View.VISIBLE);
-        errorMessage.setTextColor(color);
+        int red = view.getResources().getColor(R.color.red);
+        errorMessage.setTextColor(red);
     }
+    public void displaySuccessMessage(String sourceString) {
+        errorMessage.setText(Html.fromHtml(sourceString));
+        errorMessage.setVisibility(View.VISIBLE);
+        int green = view.getResources().getColor(R.color.green);
+        errorMessage.setTextColor(green);
+    }
+
 
     /**
      * Handle user password update.
@@ -180,21 +183,13 @@ public class ProfileInfo extends Fragment {
      */
     public void changePassword(
             FirebaseUser user, @NonNull String newPassword, @NonNull String confirmPassword) {
-        if (!newPassword.equals(confirmPassword)) {
-            displayMessage("Password do not match.", red);
-            return;
-        }
-        if (newPassword.length() < 6 || confirmPassword.length() < 6) {
-            displayMessage("Your password must be longer than 6 characters", red);
-            return;
-        }
         user.updatePassword(newPassword).addOnCompleteListener(new OnCompleteListener < Void > () {
             @Override
             public void onComplete(@NonNull Task < Void > task) {
                 if (task.isSuccessful()) {
-                    displayMessage("Successfully change your password", green);
+                    displaySuccessMessage("Successfully change your password");
                 } else {
-                    displayMessage("Cannot update password.", red);
+                    displayErrorMessage("Cannot update password.");
                 }
             }
         });
@@ -211,12 +206,12 @@ public class ProfileInfo extends Fragment {
             @Override
             public void onComplete(@NonNull Task < Void > task) {
                 if (task.isSuccessful()) {
-                    displayMessage("Successfully change your email", green);
+                    displaySuccessMessage("Successfully change your email");
                     rootRef.child("users").child(user.getUid()).child("email").setValue(email);
                     currentEmail = email;
                     emailField.setHint(currentEmail);
                 } else {
-                    displayMessage("Cannot update email.", red);
+                    displayErrorMessage("Cannot update email.");
                 }
             }
         });
@@ -240,11 +235,12 @@ public class ProfileInfo extends Fragment {
                     @Override
                     public void onComplete(@NonNull Task < Void > task) {
                         if (task.isSuccessful()) {
-                            updateUserInformation(user);
-                            displayMessage("Your profile is updated!", green);
-                            displayUserInfo();
+                            if (updateUserInformation(user)){
+                                displaySuccessMessage("Your profile is updated!");
+                                displayUserInfo();
+                            }
                         } else {
-                            displayMessage("Your old password is not correct.", red);
+                            displayErrorMessage("Your old password is not correct.");
                         }
                     }
                 });
@@ -262,7 +258,7 @@ public class ProfileInfo extends Fragment {
      * Updates user information after user has verified their old password.
      * @param user The current logged in Firebase user
      */
-    public void updateUserInformation(@NonNull FirebaseUser user) {
+    public boolean updateUserInformation(@NonNull FirebaseUser user) {
         DatabaseReference rootRef = FirebaseDatabase.getInstance().getReference();
         SharedPreferences.Editor editor = preferences.edit();
 
@@ -281,6 +277,14 @@ public class ProfileInfo extends Fragment {
             editor.putString("userEmail", email);
         }
         if (!newPassword.isEmpty() && !confirmPassword.isEmpty()) {
+            if (!newPassword.equals(confirmPassword)) {
+                displayErrorMessage("Password do not match.");
+                return false;
+            }
+            if (newPassword.length() < 6 || confirmPassword.length() < 6) {
+                displayErrorMessage("Your password must be longer than 6 characters");
+                return false;
+            }
             changePassword(user, newPassword, confirmPassword);
         }
 
@@ -289,6 +293,7 @@ public class ProfileInfo extends Fragment {
             editor.putString("userNotes", notes);
         }
         editor.commit();
+        return true;
     }
 
     /**

--- a/app/src/main/res/layout/fragment_profile_info.xml
+++ b/app/src/main/res/layout/fragment_profile_info.xml
@@ -84,36 +84,30 @@
             android:padding="10dp"
             android:layout_marginBottom="10dp"/>
 
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
 
-            <EditText
-                android:id="@+id/profileNewPassword"
-                android:layout_width="0dp"
-                android:layout_height="50dp"
-                android:ems="10"
-                android:inputType="textPassword"
-                android:background="@color/gray"
-                android:padding="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginRight="10dp"
-                android:hint="New Password"
-                android:layout_weight="0.5"/>
+        <EditText
+            android:id="@+id/profileNewPassword"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:ems="10"
+            android:inputType="textPassword"
+            android:background="@color/gray"
+            android:padding="10dp"
+            android:layout_marginBottom="10dp"
+            android:hint="New Password" />
 
-            <EditText
-                android:id="@+id/profileNewPassword2"
-                android:layout_width="0dp"
-                android:layout_height="50dp"
-                android:ems="10"
-                android:inputType="textPassword"
-                android:background="@color/gray"
-                android:padding="10dp"
-                android:layout_marginBottom="10dp"
-                android:hint="Confirm Password"
-                android:layout_weight="0.5"/>
-        </LinearLayout>
+        <EditText
+            android:id="@+id/profileConfirmPassword"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:ems="10"
+            android:inputType="textPassword"
+            android:background="@color/gray"
+            android:padding="10dp"
+            android:layout_marginBottom="10dp"
+            android:hint="Confirm Password"
+       />
+
 
         <EditText
             android:id="@+id/profileNotes"


### PR DESCRIPTION
## Issue
- The old password and new password field are on the same line, which covered the placeholder text. 
- Also when user's new password and confirm password field are different, the error message didn't display. 

## Fixes
- The problem is the new password and confirm password field's error message are overridden by the success message since we call displaySuccessMessage() right after updateUserInformation(user), regardless of whether the updateUserInformation is successful or not. 
- Add a boolean condition check to make sure to display success message only if updateUserInformation are successful. 

```
  if (updateUserInformation(user)){
        displaySuccessMessage("Your profile is updated!");
        displayUserInfo();
    }
```
<img width="379" alt="Screen Shot 2021-04-17 at 11 39 12 AM" src="https://user-images.githubusercontent.com/22923895/115118610-09891900-9f72-11eb-88c3-00f1a5f58747.png">
