### PR TITLE
Added check for empty task name during edit action

### DIFF
--- a/app/src/main/java/com/example/caregiver/EditTask.java
+++ b/app/src/main/java/com/example/caregiver/EditTask.java
@@ -117,6 +117,11 @@ public class EditTask extends AppCompatActivity {
 
         // post updated task details
         String updatedTaskName = String.valueOf(taskNameField.getText());
+        if(updatedTaskName.isEmpty()){
+            displayMessage("Please enter a task name.",
+                    ContextCompat.getColor(getApplicationContext(), R.color.red));
+            return;
+        }
         String updatedNotes = String.valueOf(taskNotesField.getText());
         // formulate path
         path = createPath(currTask.caregiveeId, updatedRoom, currTask.taskId);
@@ -201,7 +206,7 @@ public class EditTask extends AppCompatActivity {
                 Intent intent = new Intent(this, Dashboard.class);
                 startActivity(intent);
             } else {
-                displayMessage("Your task cannot be updated", red);
+                displayMessage("Your task cannot be updated. Please try again later.", red);
             }
         });
     }


### PR DESCRIPTION
Added a simple check to make sure user cannot update a task with an empty task name field:
`if(updatedTaskName.isEmpty()){
           displayMessage("Please enter a task name.",
                   ContextCompat.getColor(getApplicationContext(), R.color.red));
           return;
}`

https://user-images.githubusercontent.com/30156526/115121034-9934c480-9f7e-11eb-9221-5e7d6868c0cc.mov

