### PR TITLE
Fix Add Task rooms issue 

### DIFF
--- a/app/src/main/java/com/example/caregiver/AddTask.java
+++ b/app/src/main/java/com/example/caregiver/AddTask.java
@@ -264,8 +264,10 @@ public class AddTask extends AppCompatActivity {
         }
     }
 
+    /**
+     * Function to query the latest room under a caregivee id.
+     */
     protected void queryLatestRooms(){
-
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         String caregiveeNames = preferences.getString("caregiveeInfo", null);
         caregiverId = preferences.getString("userId", "");
@@ -299,8 +301,6 @@ public class AddTask extends AppCompatActivity {
     }
 
     protected void createSpinners() {
-        Log.d("createSpinners is called!", caregiveeRooms.toString());
-
         // Render list on the caregivee spinner
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(
                 this, android.R.layout.simple_spinner_item, caregivee_spinner_options);

--- a/app/src/main/java/com/example/caregiver/App.java
+++ b/app/src/main/java/com/example/caregiver/App.java
@@ -18,5 +18,11 @@ public class App extends Application {
     public interface TaskCallback {
         void onDataReceived(List<Task> tasks);
     }
+
+
+    /* Return a list of rooms associated with that caregivee */
+    public interface RoomCallback {
+        void onDataReceived(List<String> rooms);
+    }
 }
 

--- a/app/src/main/java/com/example/caregiver/TaskFragment.java
+++ b/app/src/main/java/com/example/caregiver/TaskFragment.java
@@ -226,9 +226,7 @@ public class TaskFragment extends Fragment {
             Gson gson = new Gson();
             if (caregiveeInfo != null && caregiveeRooms != null) {
                 String caregiveeInfoStr = gson.toJson(caregiveeInfo);
-                String caregiveeRoomStr = gson.toJson(caregiveeRooms);
                 editor.putString("caregiveeInfo", caregiveeInfoStr);
-                editor.putString("caregiveeRooms", caregiveeRoomStr);
                 editor.apply();
             }
         }

--- a/app/src/main/java/com/example/caregiver/model/Task.java
+++ b/app/src/main/java/com/example/caregiver/model/Task.java
@@ -210,4 +210,32 @@ public class Task implements Parcelable {
         task.dateCompleted = completionDate;
         task.timeCompleted = completionTime;
     }
+
+    public void getAllRooms(String caregiveeId,  App.RoomCallback callback){
+        Gson gson = new Gson();
+        JsonParser parser = new JsonParser();
+        DatabaseReference database = FirebaseDatabase.getInstance().getReference();
+        DatabaseReference ref = database.child("users/" + caregiveeId);
+        ref.addValueEventListener(new ValueEventListener() {
+            @RequiresApi(api = Build.VERSION_CODES.N)
+            @Override
+            public void onDataChange(@NonNull DataSnapshot snapshot) {
+                Object firebaseRooms = snapshot.child("rooms").getValue();
+                if (firebaseRooms != null){
+                    JsonObject roomObject = (JsonObject) parser.parse(gson.toJson(firebaseRooms));
+                    List<String> rooms = roomObject.entrySet().stream().map(
+                            i -> i.getKey()).collect(Collectors.toCollection(ArrayList::new));
+                    Log.d("rooms!!!!", rooms.toString());
+                    callback.onDataReceived(rooms);
+                } else {
+                    callback.onDataReceived(null);
+                }
+            }
+
+            @Override
+            public void onCancelled(@NonNull DatabaseError error) {
+
+            }
+        });
+    }
 }

--- a/app/src/main/java/com/example/caregiver/model/Task.java
+++ b/app/src/main/java/com/example/caregiver/model/Task.java
@@ -225,7 +225,6 @@ public class Task implements Parcelable {
                     JsonObject roomObject = (JsonObject) parser.parse(gson.toJson(firebaseRooms));
                     List<String> rooms = roomObject.entrySet().stream().map(
                             i -> i.getKey()).collect(Collectors.toCollection(ArrayList::new));
-                    Log.d("rooms!!!!", rooms.toString());
                     callback.onDataReceived(rooms);
                 } else {
                     callback.onDataReceived(null);


### PR DESCRIPTION
## Issue
- **Issue 1**: There are sometimes 'duplicate' rooms within the spinner, such as seeing a room appear twice. 
- **Issue 2**: When a new room is updated on Firebase, we don't see it appear on the dropdown rooms in Add Task

## Solution
- For **Issue 1**, this is because we doesn't check if list is a set. However, reading straight from Firebase had prevent this. 
- For **Issue 2**, this is because the data we got form 'AddTask' is not up to date with Firebase. 
     + The old data is read from SharedPreferences from the Task page, and the SharedPreferences is only loaded once when user click on Task page 
     + Moreover, when we refactor the Task model object, it only gets Room that has at least 1 task underneath it. 

- To solve this, we create a unique function that handle getting Rooms for one specific caregivee in **model/Task.java**: 
```java
public void onDataChange(@NonNull DataSnapshot snapshot) {
      Object firebaseRooms = snapshot.child("rooms").getValue();

      // If user has some rooms, load them 
      if (firebaseRooms != null){
          JsonObject roomObject = (JsonObject) parser.parse(gson.toJson(firebaseRooms));
          List<String> rooms = roomObject.entrySet().stream().map(
                  i -> i.getKey()).collect(Collectors.toCollection(ArrayList::new));
          callback.onDataReceived(rooms);
      } 
      // If user does not have any rooms, return a null object. 
      else {
          callback.onDataReceived(null);
      }
  }
 ```

https://user-images.githubusercontent.com/22923895/116117124-e3f2c280-a689-11eb-9100-369963c62011.mov

