### PR TITLE
Fix timer counting backwards + display time

### DIFF
--- a/app/src/main/java/com/example/caregiver/TaskFinish.java
+++ b/app/src/main/java/com/example/caregiver/TaskFinish.java
@@ -88,7 +88,6 @@ public class TaskFinish extends AppCompatActivity {
         GradientDrawable helpBg = (GradientDrawable) timerCircle.getBackground();
         helpBg.setColor(getResources().getColor(R.color.teal_700));
 
-
         Bundle b = getIntent().getExtras();
         if (b != null) {
             String taskStr = b.getString("finishTask");

--- a/app/src/main/java/com/example/caregiver/TaskFinish.java
+++ b/app/src/main/java/com/example/caregiver/TaskFinish.java
@@ -88,20 +88,16 @@ public class TaskFinish extends AppCompatActivity {
         GradientDrawable helpBg = (GradientDrawable) timerCircle.getBackground();
         helpBg.setColor(getResources().getColor(R.color.teal_700));
 
-//        // Add listener on the back arrow on the single task view screen
-//        ImageView backArrow = (ImageView) findViewById(R.id.backArrow);
-//        backArrow.setOnClickListener(new View.OnClickListener() {@Override
-//        public void onClick(View v) {
-//            Intent i = new Intent(TaskFinish.this, Dashboard.class);
-//            startActivity(i);
-//        }
-//        });
 
         Bundle b = getIntent().getExtras();
         if (b != null) {
             String taskStr = b.getString("finishTask");
             String taskTime = b.getString("finishTime");
-            timerCircle.setText(taskTime + ":00");
+
+            int mins = Integer.parseInt(taskTime) / 60;
+            int seconds = Integer.parseInt(taskTime) - mins * 60;
+            String displayTime = String.valueOf(mins) + ":" + String.valueOf(seconds);
+            timerCircle.setText(displayTime);
             doSomething(taskStr, Integer.valueOf(taskTime));
         } else {
             Log.d("error", "Cannot get task.");

--- a/app/src/main/java/com/example/caregiver/TaskSingleView.java
+++ b/app/src/main/java/com/example/caregiver/TaskSingleView.java
@@ -99,7 +99,7 @@ public class TaskSingleView extends AppCompatActivity {
                 AlertDialog.Builder builder = new AlertDialog.Builder(TaskSingleView.this);
                 timer.stop();
                 timeStarted = false;
-                timeWhenStopped = Math.abs(timer.getBase() -  SystemClock.elapsedRealtime());
+                timeWhenStopped = Math.abs(SystemClock.elapsedRealtime() -  timer.getBase());
 
                 // Pop up open dialog-box to check if they actually finished task.
                 builder.setMessage("Finish your task?").setPositiveButton("Yes", new DialogInterface.OnClickListener() {@Override
@@ -110,7 +110,13 @@ public class TaskSingleView extends AppCompatActivity {
                     i.putExtra("finishTask", taskStr);
                     startActivity(i);
                 }
-                }).setNegativeButton("No", null);
+                }).setNegativeButton("No",  new DialogInterface.OnClickListener() {@Override
+                public void onClick(DialogInterface dialog, int which) {
+                    timer.setBase( SystemClock.elapsedRealtime() - timeWhenStopped);
+                    timer.start();
+                    timeStarted = true;
+                }
+                });
                 AlertDialog alert = builder.create();
                 alert.show();
             }


### PR DESCRIPTION
- When user click pause, the timer count backward. This is because we forgot to set the `timer.setBase()` to get it start at the miliseconds we want to continue counting from. 
```java
 public void onClick(DialogInterface dialog, int which) {
    timer.setBase( SystemClock.elapsedRealtime() - timeWhenStopped);
    timer.start();
    timeStarted = true;
 }
 ```
  
<img width="352" alt="Screen Shot 2021-04-26 at 12 39 41 PM" src="https://user-images.githubusercontent.com/22923895/116119568-93309900-a68c-11eb-8ae8-8083b294de7d.png">


https://user-images.githubusercontent.com/22923895/116122125-5f0aa780-a68f-11eb-99e7-9c21ea0e6d44.mov


